### PR TITLE
Adjust homepage contact layout

### DIFF
--- a/content/index.md
+++ b/content/index.md
@@ -6,12 +6,20 @@
 ---
 ::: {.row}
 
-::: {.col-9 .home-column}
+::: {.col-12 .home-column}
 
 # __Chen, Liang-Ting 陳亮廷__
 
 
 ✉️ [ltchen@iis.sinica.edu.tw](<javascript:location='&#109;&#97;i&#108;t&#111;&#58;\u006c\u0074\u0063\u0068\u0065\u006e\u0040\u0069\u0069\u0073\u002e\u0073\u0069\u006e\u0069\u0063\u0061\u002e\u0065\u0064\u0075\u002e\u0074\u0077';void 0>)
+
+:::
+
+:::
+
+::: {.row}
+
+::: {.col-8 .col-sm-9 .home-column}
 
 Assistant Research Fellow (Assistant Professor)\
 [Institute of Information Science](https://www.iis.sinica.edu.tw)\
@@ -19,7 +27,7 @@ Assistant Research Fellow (Assistant Professor)\
 
 :::
 
-::: {.col-3 .home-column}
+::: {.col-4 .col-sm-3 .home-column}
 <img src="/img/profile.jpg" srcset="/img/profile-hires.jpg 2x" class="profile-photo rounded-circle" alt="Profile Photo">
 :::
 


### PR DESCRIPTION
## What changed
- Put the name and email in their own full-width (`col-12`) row.
- Move the contact/affiliation text into a separate left column.
- Keep the profile photo in a separate right column.
- Use responsive Bootstrap widths: `8/12 + 4/12` on the smallest screens and `9/12 + 3/12` from the `sm` breakpoint upward.

## Scope
Only `content/index.md` is changed. Existing profile-photo styling and all other homepage content remain unchanged.

## Validation
Compared the branch against `source`: one commit, one modified file, 10 additions and 2 deletions.