### PR TITLE
Pre-render Forester pages before publishing

### DIFF
--- a/.github/workflows/hakyll.yml
+++ b/.github/workflows/hakyll.yml
@@ -79,6 +79,22 @@ jobs:
       - name: Check the site
         run: make check STACK_FLAGS="${FLAGS}"
 
+      - name: Install XSLT processor
+        run: sudo apt-get update && sudo apt-get install -y xsltproc
+
+      - name: Pre-render Forester pages
+        shell: bash
+        run: |
+          set -euo pipefail
+          stylesheet="$PWD/_site/posts/default.xsl"
+          test -f "$stylesheet"
+
+          while IFS= read -r -d '' xml; do
+            html="${xml%.xml}.html"
+            xsltproc --output "$html" "$stylesheet" "$xml"
+            rm "$xml"
+          done < <(find _site/posts -type f -name 'index.xml' -print0)
+
       - name: Upload GitHub Pages artifact
         uses: actions/upload-pages-artifact@v4
         with:


### PR DESCRIPTION
## What changed

- install `xsltproc` in the GitHub Pages build job
- after the existing Hakyll build and checks, transform every `_site/posts/**/index.xml` with the deployed `_site/posts/default.xsl`
- write the transformed result as `index.html` and remove the corresponding XML before uploading the Pages artifact

## Why

Forester pages are currently published as XML and transformed client-side with XSLT. Safari visibly repaints the page during that XML/XSLT document lifecycle, and browser-side XSLT is also becoming a compatibility liability. Pre-rendering the same stylesheet during CI makes the published pages ordinary HTML while leaving Forester generation and the Hakyll integration unchanged.

## Scope

This deliberately changes only the deployment artifact. Local Forester output remains XML, and the existing site checks still run against the normal Hakyll build before pre-rendering.

## Validation

- branch is based directly on `source`
- diff is limited to `.github/workflows/hakyll.yml`
- GitHub Actions on this PR should exercise the full build and the new transformation step
