### PR TITLE
Render Forester HTML from Make targets

### DIFF
--- a/.github/workflows/hakyll.yml
+++ b/.github/workflows/hakyll.yml
@@ -73,27 +73,14 @@ jobs:
           restore-keys: |
             stack-${{ runner.os }}-
 
+      - name: Install XSLT processor
+        run: sudo apt-get update && sudo apt-get install -y xsltproc
+
       - name: Build the site
         run: make build STACK_FLAGS="${FLAGS}"
 
       - name: Check the site
         run: make check STACK_FLAGS="${FLAGS}"
-
-      - name: Install XSLT processor
-        run: sudo apt-get update && sudo apt-get install -y xsltproc
-
-      - name: Pre-render Forester pages
-        shell: bash
-        run: |
-          set -euo pipefail
-          stylesheet="$PWD/_site/posts/default.xsl"
-          test -f "$stylesheet"
-
-          while IFS= read -r -d '' xml; do
-            html="${xml%.xml}.html"
-            xsltproc --output "$html" "$stylesheet" "$xml"
-            rm "$xml"
-          done < <(find _site/posts -type f -name 'index.xml' -print0)
 
       - name: Upload GitHub Pages artifact
         uses: actions/upload-pages-artifact@v4

--- a/Makefile
+++ b/Makefile
@@ -4,27 +4,41 @@ WATCHEXEC ?= watchexec
 XSLTPROC ?= xsltproc
 STACK_FLAGS ?=
 
-.PHONY: forest forest-incremental render-forest test hakyll build check clean serve watch
+.PHONY: check-tools check-stack check-forester check-watchexec check-xsltproc \
+	forest forest-incremental render-forest test hakyll build check clean serve watch
+
+check-tools: check-stack check-forester check-watchexec check-xsltproc
+
+check-stack:
+	@command -v "$(STACK)" >/dev/null 2>&1 || { echo "$(STACK) is required but was not found in PATH" >&2; exit 1; }
+
+check-forester:
+	@command -v "$(FORESTER)" >/dev/null 2>&1 || { echo "$(FORESTER) is required but was not found in PATH" >&2; exit 1; }
+
+check-watchexec:
+	@command -v "$(WATCHEXEC)" >/dev/null 2>&1 || { echo "$(WATCHEXEC) is required but was not found in PATH" >&2; exit 1; }
+
+check-xsltproc:
+	@command -v "$(XSLTPROC)" >/dev/null 2>&1 || { echo "$(XSLTPROC) is required but was not found in PATH" >&2; exit 1; }
 
 build: build-forest build-hakyll
 	$(MAKE) render-forest
 
 # Forester does not remove files for deleted trees, so always rebuild its
 # ignored output directory from scratch.
-rebuild-forest:
+rebuild-forest: check-forester
 	rm -rf forest/output
 	cd forest && $(FORESTER) build
 
 # Keep generated files present while Hakyll is watching. Clean builds still use
 # the target above so output for deleted trees is removed before deployment.
-build-forest:
+build-forest: check-forester
 	cd forest && $(FORESTER) build
 
 # Pre-render Forester XML after Hakyll has assembled the deployed XSLT tree.
 # Read XML from Forester's output so this can be rerun even after the deployed
 # XML copies have been removed.
-render-forest:
-	@command -v "$(XSLTPROC)" >/dev/null || { echo "xsltproc is required for make render-forest" >&2; exit 1; }
+render-forest: check-xsltproc
 	@set -eu; \
 		stylesheet="$$PWD/_site/posts/default.xsl"; \
 		test -f "$$stylesheet"; \
@@ -36,22 +50,21 @@ render-forest:
 			rm -f "_site/posts/$$rel"; \
 		done
 
-test:
+test: check-stack
 	$(STACK) test $(STACK_FLAGS)
 
-build-hakyll:
+build-hakyll: check-stack
 	$(STACK) build $(STACK_FLAGS)
 	$(STACK) build $(STACK_FLAGS) --exec "site rebuild"
 
-check: test
+check: check-stack test
 	$(STACK) build $(STACK_FLAGS) --exec "site check --internal-links"
 
-clean:
+clean: check-stack
 	$(STACK) build $(STACK_FLAGS) --exec "site clean"
 	rm -rf forest/output
 
-watch: build
-	@command -v "$(WATCHEXEC)" >/dev/null || { echo "watchexec is required for make watch" >&2; exit 1; }
+watch: check-watchexec build
 	@set -eu; \
 		$(WATCHEXEC) --project-origin . --postpone --on-busy-update=queue \
 			--watch forest/trees --watch forest/assets \

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,13 @@
 STACK ?= stack
 FORESTER ?= forester
 WATCHEXEC ?= watchexec
+XSLTPROC ?= xsltproc
 STACK_FLAGS ?=
 
-.PHONY: forest forest-incremental test hakyll build check clean serve watch
+.PHONY: forest forest-incremental render-forest test hakyll build check clean serve watch
 
 build: build-forest build-hakyll
+	$(MAKE) render-forest
 
 # Forester does not remove files for deleted trees, so always rebuild its
 # ignored output directory from scratch.
@@ -17,6 +19,22 @@ rebuild-forest:
 # the target above so output for deleted trees is removed before deployment.
 build-forest:
 	cd forest && $(FORESTER) build
+
+# Pre-render Forester XML after Hakyll has assembled the deployed XSLT tree.
+# Read XML from Forester's output so this can be rerun even after the deployed
+# XML copies have been removed.
+render-forest:
+	@command -v "$(XSLTPROC)" >/dev/null || { echo "xsltproc is required for make render-forest" >&2; exit 1; }
+	@set -eu; \
+		stylesheet="$$PWD/_site/posts/default.xsl"; \
+		test -f "$$stylesheet"; \
+		find forest/output/posts -type f -name 'index.xml' -print | while IFS= read -r xml; do \
+			rel=$${xml#forest/output/posts/}; \
+			html="_site/posts/$${rel%.xml}.html"; \
+			mkdir -p "$$(dirname "$$html")"; \
+			"$(XSLTPROC)" --output "$$html" "$$stylesheet" "$$xml"; \
+			rm -f "_site/posts/$$rel"; \
+		done
 
 test:
 	$(STACK) test $(STACK_FLAGS)
@@ -40,5 +58,9 @@ watch: build
 			--watch forest/forest.toml --watch forest/theme -- \
 			$(MAKE) build-forest FORESTER="$(FORESTER)" & \
 		forester_watch_pid=$$!; \
-		trap 'kill "$$forester_watch_pid" 2>/dev/null || true; wait "$$forester_watch_pid" 2>/dev/null || true' EXIT INT TERM; \
+		$(WATCHEXEC) --project-origin . --postpone --on-busy-update=queue \
+			--watch _site/posts --exts xml,xsl -- \
+			$(MAKE) render-forest XSLTPROC="$(XSLTPROC)" & \
+		render_watch_pid=$$!; \
+		trap 'kill "$$forester_watch_pid" "$$render_watch_pid" 2>/dev/null || true; wait "$$forester_watch_pid" 2>/dev/null || true; wait "$$render_watch_pid" 2>/dev/null || true' EXIT INT TERM; \
 		$(STACK) build $(STACK_FLAGS) --exec "site watch"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ Clone the repository with its pinned Bootstrap and Forester theme submodules:
 git clone --recurse-submodules https://github.com/L-TChen/L-TChen.github.io.git
 ```
 
-The build needs Stack, OCaml 5.3, and exactly Forester 5.0. With opam:
+The build needs Stack, OCaml 5.3, exactly Forester 5.0, and `xsltproc` from
+libxslt. With opam:
 
 ```console
 opam switch create 5.3.0
@@ -21,22 +22,24 @@ Run the complete build and verification from the repository root:
 opam exec -- make check
 ```
 
-`make build` performs a clean Forester build followed by a clean Hakyll build.
-`make test` runs the Haskell adapter tests, and `make serve` builds and serves
-the combined site locally. The CI-specific Hakyll flags can be supplied with
-`STACK_FLAGS="..."`.
+`make build` builds the Forester and Hakyll outputs, then pre-renders each
+Forester `index.xml` as `_site/posts/<id>/index.html` with `xsltproc` and removes
+the deployed XML copy. `make watch` keeps the same rendering stage active as
+Forester, Hakyll, or the XSLT changes. `make test` runs the Haskell adapter tests,
+and `make serve` builds and serves the combined site locally. The CI-specific
+Hakyll flags can be supplied with `STACK_FLAGS="..."`.
 
-### Blank Forester post pages
+### Forester rendering
 
-Forester posts are generated as XML and rendered in the browser with XSLT. If
-`/posts/<id>/index.xml` appears blank even though the XML contains content,
-check that the Forester theme submodule is initialized. Without it,
-`default.xsl` is generated but its base-theme includes (`core.xsl`,
-`metadata.xsl`, `links.xsl`, and `tree.xsl`) are missing, so the browser cannot
-transform the XML into HTML. This can explain why the same page works from a
-clone on another computer.
+Forester still generates XML under `forest/output`, but the published and local
+Hakyll site is rendered to HTML ahead of time. The renderer uses
+`_site/posts/default.xsl`, after Hakyll has assembled the site-owned stylesheet
+with the Forester base-theme includes (`core.xsl`, `metadata.xsl`, `links.xsl`,
+and `tree.xsl`). This keeps the browser from having to perform the XSLT
+transformation itself.
 
-Initialize all submodules and rebuild the generated output:
+If rendering fails because the base-theme includes are missing, initialize all
+submodules and rebuild the generated output:
 
 ```console
 git submodule update --init --recursive
@@ -45,8 +48,7 @@ make build
 ```
 
 A leading `-` in `git submodule status forest/theme` means that the theme
-submodule has not been initialized. Browser developer tools may also show 404
-responses for the missing XSL files under `/posts/`.
+submodule has not been initialized.
 
 ## Author posts with Forester
 


### PR DESCRIPTION
## What changed

Follow-up to #14: move Forester XSLT pre-rendering out of the GitHub Actions-only step and make it part of the normal local build workflow.

- add `XSLTPROC ?= xsltproc` and a reusable `render-forest` Make target
- add `make check-tools` for the complete development toolchain, plus tool-specific prerequisite checks so each target fails early only on commands it actually needs
- make `make build` run `render-forest` after Forester and Hakyll have assembled `_site`
- make `make watch` run a second `watchexec` watcher on `_site/posts` for XML/XSL changes and re-render Forester HTML as Hakyll refreshes the site
- render from `forest/output/posts/**/index.xml`, so the stage can be rerun after deployed XML copies have already been removed
- move CI's `xsltproc` installation before `make build` and remove the duplicated inline rendering shell block
- update the README to document the `xsltproc` dependency and ahead-of-time rendering behavior

## Why

PR #14 established ahead-of-time XSLT rendering for the published Pages artifact. Keeping that logic only in CI meant local `make build` and `make watch` still behaved differently from production. Centralizing the rendering in the Makefile gives local builds, live development, link checking, and deployment the same final Forester HTML artifact. Explicit tool prerequisites also make missing local dependencies fail immediately with a clear diagnostic.

## Validation

- branch is based directly on current `source`
- Makefile parses successfully under `/bin/sh`/GNU make
- fixture test verified nested `forest/output/posts/.../index.xml` paths render to matching `_site/posts/.../index.html` paths and deployed XML copies are removed
- `make check-tools` covers Stack, Forester, watchexec, and xsltproc; individual build targets depend only on the corresponding tool checks
- full Stack/Forester/Hakyll validation is delegated to GitHub Actions on this PR
